### PR TITLE
modern CMake compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,3 +73,5 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/wildcardtree.cpp
 )
 
+# Make tfs_SRC available to parent scope
+set(tfs_SRC ${tfs_SRC} PARENT_SCOPE)


### PR DESCRIPTION
modern CMake (at least 3.28.3) needs this line, or it will error out with

>CMake Error at CMakeLists.txt:54 (add_executable):
  No SOURCES given to target: tfs
