### PR TITLE
missing uint32_t definition

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -39,6 +39,8 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#include <cstdint>
+
 
 #ifdef _WIN32
 #ifndef NOMINMAX


### PR DESCRIPTION
```make
[  1%] Building CXX precompiled header cotire/tfs_CXX_prefix.hxx.gch (...)
In file included from /home/hans/projects/POTCP/RealMap-Global-8.0-TFS1.2/src/otpch.h:23,
                 from /home/hans/projects/POTCP/RealMap-Global-8.0-TFS1.2/build/cotire/tfs_CXX_prefix.cxx:4,
                 from /home/hans/projects/POTCP/RealMap-Global-8.0-TFS1.2/build/cotire/tfs_CXX_prefix.hxx:4:
/home/hans/projects/POTCP/RealMap-Global-8.0-TFS1.2/src/definitions.h:78:31: error: ‘uint32_t’ was not declared in this scope
   78 | typedef std::vector<std::pair<uint32_t, uint32_t>> IPList;
      |                               ^~~~~~~~
/home/hans/projects/POTCP/RealMap-Global-8.0-TFS1.2/src/definitions.h:42:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```